### PR TITLE
Request object oAuth keys updated ng ...

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -65,11 +65,11 @@ function Client(options) {
     this.auth = { username: options.username, password: options.password, sendImmediately: true };
   } else if (options.consumerKey && options.consumerSecret && options.token && options.tokenSecret) {
     this.auth = {
-      consumerKey: options.consumerKey,
-      consumerSecret: options.consumerSecret,
+      consumer_key: options.consumerKey,
+      consumer_secret: options.consumerSecret,
       token: options.token,
-      tokenSecret: options.tokenSecret
-    }
+      token_secret: options.tokenSecret
+    };
   } else {
     throw new Error('No authentication specified, use either Basic Authentication or OAuth.');
   }


### PR DESCRIPTION
All oAuth requests failing.  The request library requires oAuth object to have consumer/token keys and secrets with underscore, not camelCase.
