### PR TITLE
last is immutable error and ability to pass in no search parameters.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -110,6 +110,8 @@ function Client(options) {
  * @api private
  */
 Client.prototype.onResponse = function(callback, options, err, response, body) {
+  options.retryCount = options.retryCount || 0;
+
   if (err) {
     if (err.code === 'ECONNRESET' || err.message === 'socket hang up') {
       if (this.retry && options.retryCount <= this.maxRetry) return this.doRetry(options, callback);
@@ -123,7 +125,7 @@ Client.prototype.onResponse = function(callback, options, err, response, body) {
 
   if (response.statusCode === 429) {
     if (this.retry && options.retryCount <= this.maxRetry) {
-      return this.doRetry(options, callback, parseInt(response.headers['x-retry-after'] || 10, 10) * 1000);
+      return this.doRetry(options, callback, parseInt(response.headers['x-rate-limit-reset'] || 10, 10) * 1000);
     } else {
       callback(); // clears the item from the queue
       return options.callback(new Error('429: Too many requests'));

--- a/lib/mixins/link.js
+++ b/lib/mixins/link.js
@@ -38,7 +38,12 @@ function link(definition) {
         link['class'] = 'page'
 
       newResource = new (getResource(link['class']))(this, { _links: { self: link }});
-      this[key] = _buildFunction(newResource);
+      if (key === 'last') {
+        this.lastPage =
+        this[key] = _buildFunction(newResource);
+      } else {
+        this[key] = _buildFunction(newResource);
+      }
     }
   }
 }

--- a/lib/mixins/link.js
+++ b/lib/mixins/link.js
@@ -29,7 +29,7 @@ function link(definition) {
 
       // resources like next, previous can be null
       if (link === null) {
-        this[key] = _buildFunction(null);
+        this[key] = _buildFunction(key, null);
         continue;
       }
 
@@ -40,9 +40,9 @@ function link(definition) {
       newResource = new (getResource(link['class']))(this, { _links: { self: link }});
       if (key === 'last') {
         this.lastPage =
-        this[key] = _buildFunction(newResource);
+        this[key] = _buildFunction(key, newResource);
       } else {
-        this[key] = _buildFunction(newResource);
+        this[key] = _buildFunction(key, newResource);
       }
     }
   }
@@ -51,12 +51,18 @@ function link(definition) {
 /**
  * Builds the function for the resource.
  *
+ * These functions are one time use only to prevent memory leaks.
+ *
+ * @param {String} key Key for the the resource, so it can cleanup the function after use.
  * @param {Object|Null} resource The resource for the getter.
  * @return {Function}
  * @api private
  */
-function _buildFunction(resource) {
+function _buildFunction(key, resource) {
   return function(callback) {
+    // cleanup this resource (so all parents aren't retained)
+    this[key] = null;
+
     if (typeof callback == 'function') {
       if (resource !== null) return resource.exec.call(resource, callback);
       else return callback(null, null);

--- a/lib/resource/index.js
+++ b/lib/resource/index.js
@@ -19,7 +19,12 @@ exports = module.exports = Resource;
  * @api private
  */
 function Resource(parent, definition) {
-  this.parent = parent;
+  // always get top parent so we are not keeping a giant chain of resources
+  if (parent.parent) {
+    this.parent = parent.parent;
+  } else {
+    this.parent = parent;
+  }
   this.definition = definition;
 
   // add mixins

--- a/lib/resource/page.js
+++ b/lib/resource/page.js
@@ -103,6 +103,10 @@ Page.prototype.search = function(params, callback) {
     search: qs.stringify(params)
   };
 
+  if(!params) {
+    return getResource(className).search(this, URL.format(baseUrl), callback);
+  }
+
   return getResource(className).search(this, URL.format(urlObj), callback);
 }
 


### PR DESCRIPTION
There are 2 fixes here:
1) We had the problem that an html5 module was setting last, so this update kept the 2 working together.  This may or may not be a good update to pull, your choice.  
2) If we made the search params dynamic and nothing was passed in, we'd error out on null with a call to the desk servers.  This makes search able to accept null params without failing and returning the results as expected.