### PR TITLE
Passing Error in error callback on a 429 rate limit

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -69,7 +69,7 @@ function Client(options) {
   } else {
     this.baseUrl = 'https://' + this.subdomain + '.desk.com';
   }
-  
+
   if (options.username && options.password) {
     this.auth = { username: options.username, password: options.password, sendImmediately: true };
   } else if (options.consumerKey && options.consumerSecret && options.token && options.tokenSecret) {
@@ -87,7 +87,7 @@ function Client(options) {
   this.maxRetry = options.maxRetry || 3;
   this.logger = options.logger || null;
   this.queue = async.queue(this.request.bind(this), 60);
-  
+
   linkMixin.call(this, JSON.parse(fs.readFileSync(__dirname + '/resources.json', 'utf-8')));
 }
 
@@ -126,7 +126,7 @@ Client.prototype.onResponse = function(callback, options, err, response, body) {
       return this.doRetry(options, callback, parseInt(response.headers['x-retry-after'] || 10, 10) * 1000);
     } else {
       callback(); // clears the item from the queue
-      return options.callback('error', new Error('Too many requests.'));
+      return options.callback(new Error('429: Too many requests'));
     }
   } else {
     callback(); // clears the item from the queue
@@ -134,7 +134,7 @@ Client.prototype.onResponse = function(callback, options, err, response, body) {
       return options.callback(new Error(body.message), body, response);
     return options.callback(null, body, response);
   }
-}
+};
 
 /**
  * Re-enqueue the request after a specified timeout.
@@ -148,13 +148,13 @@ Client.prototype.onResponse = function(callback, options, err, response, body) {
  *   - `callback` the callback will be called with the response
  *
  * @param {Object} options The request options.
- * @param {Function} callback The callback keeps track of the queue. 
+ * @param {Function} callback The callback keeps track of the queue.
  * @param {Number} timeout The timeout before we retry the request.
  * @api private
  */
 Client.prototype.doRetry = function(options, callback, timeout) {
   timeout = timeout || 5000;
-  
+
   options.retryCount = options.retryCount || 0;
   options.retryCount += 1;
 


### PR DESCRIPTION
client.js:129 is: `return options.callback('error', new Error('Too many requests.')`

This calls back into index.js:85 (`Resource.prototype.exec`), which passes only the first parameter back to the user.

The result is the library end-user sees only the string `"error"`on a rate limit, which is not at all helpful.  This PR passes back the full Error with the 429 response code.