### PR TITLE
Fix rate limiting

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -110,6 +110,8 @@ function Client(options) {
  * @api private
  */
 Client.prototype.onResponse = function(callback, options, err, response, body) {
+  options.retryCount = options.retryCount || 0;
+
   if (err) {
     if (err.code === 'ECONNRESET' || err.message === 'socket hang up') {
       if (this.retry && options.retryCount <= this.maxRetry) return this.doRetry(options, callback);
@@ -123,7 +125,7 @@ Client.prototype.onResponse = function(callback, options, err, response, body) {
 
   if (response.statusCode === 429) {
     if (this.retry && options.retryCount <= this.maxRetry) {
-      return this.doRetry(options, callback, parseInt(response.headers['x-retry-after'] || 10, 10) * 1000);
+      return this.doRetry(options, callback, parseInt(response.headers['x-rate-limit-reset'] || 10, 10) * 1000);
     } else {
       callback(); // clears the item from the queue
       return options.callback('error', new Error('Too many requests.'));


### PR DESCRIPTION
Rate limiting currently does not work
Two fixes here:
- The header sent from desk has changed.
- If you do not have a retryCount, i.e. retryCount is undefined, then this is always false: `this.retry && options.retryCount <= this.maxRetry`. Setting a default retryCount was set in doRetry, but by then it's too late.