### PR TITLE
Check that body is an object when error is thrown

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -130,7 +130,7 @@ Client.prototype.onResponse = function(callback, options, err, response, body) {
     }
   } else {
     callback(); // clears the item from the queue
-    if (response.statusCode > 299 && 'message' in body)
+    if (response.statusCode > 299 && typeof body == 'object' && 'message' in body)
       return options.callback(new Error(body.message), body, response);
     return options.callback(null, body, response);
   }


### PR DESCRIPTION
Recently desk.com went down and the request had returned a string
causing a fatal error in my application due to this unhandled exception

checking that body is an object fixes this issue
