### PR TITLE
Fix replace field issue on updates.

### DIFF
--- a/lib/mixins/update.js
+++ b/lib/mixins/update.js
@@ -12,7 +12,7 @@ exports.update = update;
 
 /**
  * Get only changed properties as a hash.
- * 
+ *
  * @return {Object}
  * @api private
  */
@@ -38,9 +38,13 @@ function update(properties, callback) {
   }
 
   var key, changed;
+  var exceptions = ['addresses_update_action', 'emails_update_action', 'phone_numbers_update_action'];
   for (key in properties) {
-    if ('set' + inflection.camelize(key) in this)
+    if ('set' + inflection.camelize(key) in this) {
       this['set' + inflection.camelize(key)](properties[key]);
+    } else if(exceptions.indexOf(key) != -1) {
+      this._changed[key] = properties[key];
+    }
   }
 
   changed = this._getChangedProperties();


### PR DESCRIPTION
Replace flags such as 'addresses_update_action', 'emails_update_action', and 'phone_numbers_update_action' were not working on updates before this fix.
